### PR TITLE
Restore framework kernel and implement inventory foundations

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,75 +1,84 @@
-<?namespace App\Http\Controllers;
+<?php
 
-use App\Models\Product;
+namespace App\Http\Controllers;
+
 use App\Models\Category;
+use App\Models\Product;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
 
 class ProductController extends Controller
 {
     public function index()
     {
-        $products = Product::with('category')->paginate(10);
+        $products = Product::with('category')->latest()->paginate(10);
+
         return view('products.index', compact('products'));
     }
 
     public function create()
     {
-        $categories = Category::all();
+        $categories = Category::orderBy('name')->get();
+
         return view('products.create', compact('categories'));
     }
 
     public function store(Request $request)
     {
-        $request->validate([
-            'name'       => 'required|string|max:255',
-            'code'       => 'required|string|unique:products,code',
-            'category_id'=> 'nullable|exists:categories,id',
-            'cost_price' => 'required|numeric',
-            'sale_price' => 'required|numeric',
-            'image'      => 'nullable|image|max:2048',
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'code' => ['required', 'string', 'max:50', 'unique:products,code'],
+            'description' => ['nullable', 'string'],
+            'category_id' => ['nullable', 'exists:categories,id'],
+            'stock' => ['required', 'integer', 'min:0'],
+            'cost_price' => ['required', 'numeric', 'min:0'],
+            'sale_price' => ['required', 'numeric', 'min:0'],
+            'image' => ['nullable', 'image', 'max:2048'],
         ]);
 
-        $data = $request->all();
-
         if ($request->hasFile('image')) {
-            $data['image'] = $request->file('image')->store('products', 'public');
+            $validated['image'] = $request->file('image')->store('products', 'public');
         }
 
-        Product::create($data);
+        Product::create($validated);
 
         return redirect()->route('products.index')->with('success', 'Producto creado correctamente');
     }
 
     public function edit(Product $product)
     {
-        $categories = Category::all();
+        $categories = Category::orderBy('name')->get();
+
         return view('products.edit', compact('product', 'categories'));
     }
 
     public function update(Request $request, Product $product)
     {
-        $request->validate([
-            'name'       => 'required|string|max:255',
-            'code'       => 'required|string|unique:products,code,'.$product->id,
-            'category_id'=> 'nullable|exists:categories,id',
-            'cost_price' => 'required|numeric',
-            'sale_price' => 'required|numeric',
-            'image'      => 'nullable|image|max:2048',
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'code' => ['required', 'string', 'max:50', Rule::unique('products', 'code')->ignore($product->id)],
+            'description' => ['nullable', 'string'],
+            'category_id' => ['nullable', 'exists:categories,id'],
+            'stock' => ['required', 'integer', 'min:0'],
+            'cost_price' => ['required', 'numeric', 'min:0'],
+            'sale_price' => ['required', 'numeric', 'min:0'],
+            'image' => ['nullable', 'image', 'max:2048'],
         ]);
-
-        $data = $request->all();
 
         if ($request->hasFile('image')) {
             if ($product->image && Storage::disk('public')->exists($product->image)) {
                 Storage::disk('public')->delete($product->image);
             }
-            $data['image'] = $request->file('image')->store('products', 'public');
+
+            $validated['image'] = $request->file('image')->store('products', 'public');
+        } else {
+            unset($validated['image']);
         }
 
-        $product->update($data);
+        $product->update($validated);
 
-        return redirect()->route('products.index')->with('success', 'Producto actualizado');
+        return redirect()->route('products.index')->with('success', 'Producto actualizado correctamente');
     }
 
     public function destroy(Product $product)

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -1,4 +1,68 @@
-protected $middlewareAliases = [
-    // ... los que ya tengas
-    'role' => \App\Http\Middleware\RoleMiddleware::class,
-];
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    /**
+     * The application's global HTTP middleware stack.
+     *
+     * These middleware are run during every request to your application.
+     *
+     * @var array<int, class-string|string>
+     */
+    protected $middleware = [
+        // \App\Http\Middleware\TrustHosts::class,
+        \App\Http\Middleware\TrustProxies::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
+        \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
+        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
+        \App\Http\Middleware\TrimStrings::class,
+        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+    ];
+
+    /**
+     * The application's middleware groups.
+     *
+     * @var array<string, array<int, class-string|string>>
+     */
+    protected $middlewareGroups = [
+        'web' => [
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            // \Illuminate\Session\Middleware\AuthenticateSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+
+        'api' => [
+            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            'throttle:api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+    ];
+
+    /**
+     * The application's route middleware groups.
+     *
+     * @var array<string, array<int, class-string|string>>
+     */
+    protected $middlewareAliases = [
+        'auth' => \App\Http\Middleware\Authenticate::class,
+        'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'auth.session' => \Illuminate\Session\Middleware\AuthenticateSession::class,
+        'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
+        'can' => \Illuminate\Auth\Middleware\Authorize::class,
+        'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
+        'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
+        'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'role' => \App\Http\Middleware\RoleMiddleware::class,
+    ];
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,11 +2,17 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Category extends Model
 {
-    protected $fillable = ['name'];
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+    ];
 
     public function products()
     {

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -2,11 +2,20 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Customer extends Model
 {
-    protected $fillable = ['name', 'phone', 'email'];
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'tax_id',
+        'address',
+    ];
 
     public function sales()
     {

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -2,13 +2,28 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Product extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
-        'name', 'code', 'description', 'category_id',
-        'stock', 'cost_price', 'sale_price', 'image'
+        'name',
+        'code',
+        'description',
+        'category_id',
+        'stock',
+        'cost_price',
+        'sale_price',
+        'image',
+    ];
+
+    protected $casts = [
+        'stock' => 'int',
+        'cost_price' => 'decimal:2',
+        'sale_price' => 'decimal:2',
     ];
 
     public function category()

--- a/app/Models/Purchase.php
+++ b/app/Models/Purchase.php
@@ -2,11 +2,25 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Purchase extends Model
 {
-    protected $fillable = ['supplier_id', 'user_id', 'date', 'total'];
+    use HasFactory;
+
+    protected $fillable = [
+        'supplier_id',
+        'user_id',
+        'reference',
+        'purchased_at',
+        'total',
+    ];
+
+    protected $casts = [
+        'purchased_at' => 'date',
+        'total' => 'decimal:2',
+    ];
 
     public function supplier()
     {

--- a/app/Models/PurchaseDetail.php
+++ b/app/Models/PurchaseDetail.php
@@ -2,11 +2,28 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class PurchaseDetail extends Model
 {
-    protected $fillable = ['purchase_id', 'product_id', 'quantity', 'unit_price', 'subtotal'];
+    use HasFactory;
+
+    protected $table = 'purchase_items';
+
+    protected $fillable = [
+        'purchase_id',
+        'product_id',
+        'quantity',
+        'unit_cost',
+        'subtotal',
+    ];
+
+    protected $casts = [
+        'quantity' => 'int',
+        'unit_cost' => 'decimal:2',
+        'subtotal' => 'decimal:2',
+    ];
 
     public function purchase()
     {

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -7,6 +7,12 @@ use Illuminate\Database\Eloquent\Model;
 
 class Role extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['name'];
-    public function users() { return $this->hasMany(User::class); }
+
+    public function users()
+    {
+        return $this->hasMany(User::class);
+    }
 }

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -2,11 +2,25 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Sale extends Model
 {
-    protected $fillable = ['customer_id', 'user_id', 'date', 'total'];
+    use HasFactory;
+
+    protected $fillable = [
+        'customer_id',
+        'user_id',
+        'reference',
+        'sold_at',
+        'total',
+    ];
+
+    protected $casts = [
+        'sold_at' => 'date',
+        'total' => 'decimal:2',
+    ];
 
     public function customer()
     {

--- a/app/Models/SaleDetail.php
+++ b/app/Models/SaleDetail.php
@@ -2,11 +2,28 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class SaleDetail extends Model
 {
-    protected $fillable = ['sale_id', 'product_id', 'quantity', 'unit_price', 'subtotal'];
+    use HasFactory;
+
+    protected $table = 'sale_items';
+
+    protected $fillable = [
+        'sale_id',
+        'product_id',
+        'quantity',
+        'unit_price',
+        'subtotal',
+    ];
+
+    protected $casts = [
+        'quantity' => 'int',
+        'unit_price' => 'decimal:2',
+        'subtotal' => 'decimal:2',
+    ];
 
     public function sale()
     {

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -2,11 +2,21 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Supplier extends Model
 {
-    protected $fillable = ['name', 'contact', 'phone', 'address'];
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'contact_name',
+        'email',
+        'phone',
+        'tax_id',
+        'address',
+    ];
 
     public function purchases()
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,10 +6,51 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-protected $fillable = ['name','email','password','role_id'];
-public function role() { return $this->belongsTo(Role::class); }
-public function isAdmin(): bool { return optional($this->role)->name === 'admin'; }
+    use HasApiTokens, HasFactory, Notifiable;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+        'role_id',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+        'password' => 'hashed',
+    ];
+
+    public function role()
+    {
+        return $this->belongsTo(Role::class);
+    }
+
+    public function isAdmin(): bool
+    {
+        return optional($this->role)->name === 'admin';
+    }
 }

--- a/database/migrations/2025_09_24_232404_create_categories_table.php
+++ b/database/migrations/2025_09_24_232404_create_categories_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2025_09_24_232405_create_products_table.php
+++ b/database/migrations/2025_09_24_232405_create_products_table.php
@@ -13,6 +13,14 @@ return new class extends Migration
     {
         Schema::create('products', function (Blueprint $table) {
             $table->id();
+            $table->string('name');
+            $table->string('code')->unique();
+            $table->text('description')->nullable();
+            $table->foreignId('category_id')->nullable()->constrained()->nullOnDelete();
+            $table->unsignedInteger('stock')->default(0);
+            $table->decimal('cost_price', 12, 2);
+            $table->decimal('sale_price', 12, 2);
+            $table->string('image')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_09_24_232406_create_customers_table.php
+++ b/database/migrations/2025_09_24_232406_create_customers_table.php
@@ -13,6 +13,11 @@ return new class extends Migration
     {
         Schema::create('customers', function (Blueprint $table) {
             $table->id();
+            $table->string('name');
+            $table->string('email')->nullable()->unique();
+            $table->string('phone')->nullable();
+            $table->string('tax_id')->nullable();
+            $table->text('address')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_09_24_232406_create_suppliers_table.php
+++ b/database/migrations/2025_09_24_232406_create_suppliers_table.php
@@ -13,6 +13,12 @@ return new class extends Migration
     {
         Schema::create('suppliers', function (Blueprint $table) {
             $table->id();
+            $table->string('name');
+            $table->string('contact_name')->nullable();
+            $table->string('email')->nullable()->unique();
+            $table->string('phone')->nullable();
+            $table->string('tax_id')->nullable();
+            $table->text('address')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_09_24_232407_create_purchases_table.php
+++ b/database/migrations/2025_09_24_232407_create_purchases_table.php
@@ -13,6 +13,11 @@ return new class extends Migration
     {
         Schema::create('purchases', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('supplier_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('reference')->nullable();
+            $table->date('purchased_at');
+            $table->decimal('total', 12, 2);
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_09_24_232408_create_sale_items_table.php
+++ b/database/migrations/2025_09_24_232408_create_sale_items_table.php
@@ -13,6 +13,11 @@ return new class extends Migration
     {
         Schema::create('sale_items', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('sale_id')->constrained('sales')->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
+            $table->unsignedInteger('quantity');
+            $table->decimal('unit_price', 12, 2);
+            $table->decimal('subtotal', 12, 2);
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_09_24_232408_create_sales_table.php
+++ b/database/migrations/2025_09_24_232408_create_sales_table.php
@@ -13,6 +13,11 @@ return new class extends Migration
     {
         Schema::create('sales', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('customer_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('reference')->nullable();
+            $table->date('sold_at');
+            $table->decimal('total', 12, 2);
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_09_24_232409_create_purchase_items_table.php
+++ b/database/migrations/2025_09_24_232409_create_purchase_items_table.php
@@ -13,6 +13,11 @@ return new class extends Migration
     {
         Schema::create('purchase_items', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('purchase_id')->constrained('purchases')->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
+            $table->unsignedInteger('quantity');
+            $table->decimal('unit_cost', 12, 2);
+            $table->decimal('subtotal', 12, 2);
             $table->timestamps();
         });
     }

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,8 +1,18 @@
-@extends('layouts.app')
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800">
+            {{ __('Panel de administración') }}
+        </h2>
+    </x-slot>
 
-@section('content')
-<div class="p-6">
-  <h1 class="text-2xl font-bold">Panel de Administración</h1>
-  <p class="mt-2">Bienvenido, {{ auth()->user()->name }}</p>
-</div>
-@endsection
+    <div class="py-12">
+        <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+            <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <h1 class="text-2xl font-bold">{{ __('Bienvenido, :name', ['name' => auth()->user()->name]) }}</h1>
+                    <p class="mt-2 text-sm text-gray-600">{{ __('Desde aquí podrás gestionar el inventario, proveedores y ventas del sistema.') }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -1,42 +1,97 @@
-@extends('layouts.app')
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800">
+            {{ __('Crear producto') }}
+        </h2>
+    </x-slot>
 
-@section('content')
-<div class="container">
-    <h1>Nuevo Producto</h1>
+    <div class="py-12">
+        <div class="mx-auto max-w-3xl sm:px-6 lg:px-8">
+            <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <form action="{{ route('products.store') }}" method="POST" enctype="multipart/form-data" class="space-y-6">
+                        @csrf
 
-    <form action="{{ route('products.store') }}" method="POST" enctype="multipart/form-data">
-        @csrf
-        <div class="mb-3">
-            <label>Nombre</label>
-            <input type="text" name="name" class="form-control" required>
+                        <div class="grid gap-6 sm:grid-cols-2">
+                            <div class="sm:col-span-2">
+                                <label for="name" class="block text-sm font-medium text-gray-700">{{ __('Nombre') }}</label>
+                                <input type="text" name="name" id="name" value="{{ old('name') }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                                @error('name')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="code" class="block text-sm font-medium text-gray-700">{{ __('Código') }}</label>
+                                <input type="text" name="code" id="code" value="{{ old('code') }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                                @error('code')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="category_id" class="block text-sm font-medium text-gray-700">{{ __('Categoría') }}</label>
+                                <select name="category_id" id="category_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    <option value="">{{ __('Sin categoría') }}</option>
+                                    @foreach ($categories as $category)
+                                        <option value="{{ $category->id }}" @selected(old('category_id') == $category->id)>{{ $category->name }}</option>
+                                    @endforeach
+                                </select>
+                                @error('category_id')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="stock" class="block text-sm font-medium text-gray-700">{{ __('Stock inicial') }}</label>
+                                <input type="number" name="stock" id="stock" min="0" value="{{ old('stock', 0) }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                                @error('stock')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="cost_price" class="block text-sm font-medium text-gray-700">{{ __('Precio de compra') }}</label>
+                                <input type="number" name="cost_price" id="cost_price" step="0.01" min="0" value="{{ old('cost_price') }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                                @error('cost_price')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="sale_price" class="block text-sm font-medium text-gray-700">{{ __('Precio de venta') }}</label>
+                                <input type="number" name="sale_price" id="sale_price" step="0.01" min="0" value="{{ old('sale_price') }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                                @error('sale_price')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+                        </div>
+
+                        <div>
+                            <label for="description" class="block text-sm font-medium text-gray-700">{{ __('Descripción') }}</label>
+                            <textarea name="description" id="description" rows="4" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">{{ old('description') }}</textarea>
+                            @error('description')
+                                <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <div>
+                            <label for="image" class="block text-sm font-medium text-gray-700">{{ __('Imagen') }}</label>
+                            <input type="file" name="image" id="image" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-indigo-600 hover:file:bg-indigo-100" />
+                            @error('image')
+                                <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <div class="flex items-center justify-end gap-2">
+                            <a href="{{ route('products.index') }}" class="inline-flex items-center rounded-md border border-transparent px-4 py-2 text-sm font-semibold text-gray-600 transition hover:bg-gray-100">{{ __('Cancelar') }}</a>
+                            <button type="submit" class="inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                {{ __('Guardar') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
-        <div class="mb-3">
-            <label>Código</label>
-            <input type="text" name="code" class="form-control" required>
-        </div>
-        <div class="mb-3">
-            <label>Categoría</label>
-            <select name="category_id" class="form-control">
-                <option value="">-- Ninguna --</option>
-                @foreach($categories as $cat)
-                    <option value="{{ $cat->id }}">{{ $cat->name }}</option>
-                @endforeach
-            </select>
-        </div>
-        <div class="mb-3">
-            <label>Precio Compra</label>
-            <input type="number" step="0.01" name="cost_price" class="form-control" required>
-        </div>
-        <div class="mb-3">
-            <label>Precio Venta</label>
-            <input type="number" step="0.01" name="sale_price" class="form-control" required>
-        </div>
-        <div class="mb-3">
-            <label>Imagen</label>
-            <input type="file" name="image" class="form-control">
-        </div>
-        <button class="btn btn-success">Guardar</button>
-        <a href="{{ route('products.index') }}" class="btn btn-secondary">Cancelar</a>
-    </form>
-</div>
-@endsection
+    </div>
+</x-app-layout>

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -1,48 +1,101 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800">
+            {{ __('Editar producto') }}
+        </h2>
+    </x-slot>
 
-@extends('layouts.app')
+    <div class="py-12">
+        <div class="mx-auto max-w-3xl sm:px-6 lg:px-8">
+            <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <form action="{{ route('products.update', $product) }}" method="POST" enctype="multipart/form-data" class="space-y-6">
+                        @csrf
+                        @method('PUT')
 
-@section('content')
-<div class="container">
-    <h1>Editar Producto</h1>
+                        <div class="grid gap-6 sm:grid-cols-2">
+                            <div class="sm:col-span-2">
+                                <label for="name" class="block text-sm font-medium text-gray-700">{{ __('Nombre') }}</label>
+                                <input type="text" name="name" id="name" value="{{ old('name', $product->name) }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                                @error('name')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
 
-    <form action="{{ route('products.update',$product) }}" method="POST" enctype="multipart/form-data">
-        @csrf @method('PUT')
-        <div class="mb-3">
-            <label>Nombre</label>
-            <input type="text" name="name" value="{{ $product->name }}" class="form-control" required>
+                            <div>
+                                <label for="code" class="block text-sm font-medium text-gray-700">{{ __('Código') }}</label>
+                                <input type="text" name="code" id="code" value="{{ old('code', $product->code) }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                                @error('code')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="category_id" class="block text-sm font-medium text-gray-700">{{ __('Categoría') }}</label>
+                                <select name="category_id" id="category_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    <option value="">{{ __('Sin categoría') }}</option>
+                                    @foreach ($categories as $category)
+                                        <option value="{{ $category->id }}" @selected(old('category_id', $product->category_id) == $category->id)>{{ $category->name }}</option>
+                                    @endforeach
+                                </select>
+                                @error('category_id')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="stock" class="block text-sm font-medium text-gray-700">{{ __('Stock disponible') }}</label>
+                                <input type="number" name="stock" id="stock" min="0" value="{{ old('stock', $product->stock) }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                                @error('stock')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="cost_price" class="block text-sm font-medium text-gray-700">{{ __('Precio de compra') }}</label>
+                                <input type="number" name="cost_price" id="cost_price" step="0.01" min="0" value="{{ old('cost_price', $product->cost_price) }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                                @error('cost_price')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="sale_price" class="block text-sm font-medium text-gray-700">{{ __('Precio de venta') }}</label>
+                                <input type="number" name="sale_price" id="sale_price" step="0.01" min="0" value="{{ old('sale_price', $product->sale_price) }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                                @error('sale_price')
+                                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                                @enderror
+                            </div>
+                        </div>
+
+                        <div>
+                            <label for="description" class="block text-sm font-medium text-gray-700">{{ __('Descripción') }}</label>
+                            <textarea name="description" id="description" rows="4" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">{{ old('description', $product->description) }}</textarea>
+                            @error('description')
+                                <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <div>
+                            <label for="image" class="block text-sm font-medium text-gray-700">{{ __('Imagen') }}</label>
+                            @if ($product->image)
+                                <img src="{{ asset('storage/'.$product->image) }}" alt="{{ $product->name }}" class="mb-3 h-20 w-20 rounded object-cover">
+                            @endif
+                            <input type="file" name="image" id="image" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-indigo-600 hover:file:bg-indigo-100" />
+                            @error('image')
+                                <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <div class="flex items-center justify-end gap-2">
+                            <a href="{{ route('products.index') }}" class="inline-flex items-center rounded-md border border-transparent px-4 py-2 text-sm font-semibold text-gray-600 transition hover:bg-gray-100">{{ __('Cancelar') }}</a>
+                            <button type="submit" class="inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                {{ __('Actualizar') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
-        <div class="mb-3">
-            <label>Código</label>
-            <input type="text" name="code" value="{{ $product->code }}" class="form-control" required>
-        </div>
-        <div class="mb-3">
-            <label>Categoría</label>
-            <select name="category_id" class="form-control">
-                <option value="">-- Ninguna --</option>
-                @foreach($categories as $cat)
-                    <option value="{{ $cat->id }}" {{ $cat->id == $product->category_id ? 'selected':'' }}>
-                        {{ $cat->name }}
-                    </option>
-                @endforeach
-            </select>
-        </div>
-        <div class="mb-3">
-            <label>Precio Compra</label>
-            <input type="number" step="0.01" name="cost_price" value="{{ $product->cost_price }}" class="form-control" required>
-        </div>
-        <div class="mb-3">
-            <label>Precio Venta</label>
-            <input type="number" step="0.01" name="sale_price" value="{{ $product->sale_price }}" class="form-control" required>
-        </div>
-        <div class="mb-3">
-            <label>Imagen</label><br>
-            @if($product->image)
-                <img src="{{ asset('storage/'.$product->image) }}" width="80" class="mb-2"><br>
-            @endif
-            <input type="file" name="image" class="form-control">
-        </div>
-        <button class="btn btn-success">Actualizar</button>
-        <a href="{{ route('products.index') }}" class="btn btn-secondary">Cancelar</a>
-    </form>
-</div>
-@endsection
+    </div>
+</x-app-layout>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -1,51 +1,80 @@
-@extends('layouts.app')
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                {{ __('Productos') }}
+            </h2>
+            <a href="{{ route('products.create') }}" class="inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                {{ __('Nuevo producto') }}
+            </a>
+        </div>
+    </x-slot>
 
-@section('content')
-<div class="container">
-    <h1>Productos</h1>
-    <a href="{{ route('products.create') }}" class="btn btn-primary mb-3">Nuevo Producto</a>
+    <div class="py-12">
+        <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+            @if (session('success'))
+                <div class="mb-4 rounded-md border border-green-200 bg-green-50 p-4 text-sm text-green-800">
+                    {{ session('success') }}
+                </div>
+            @endif
 
-    @if(session('success'))
-        <div class="alert alert-success">{{ session('success') }}</div>
-    @endif
+            <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">{{ __('Imagen') }}</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">{{ __('Nombre') }}</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">{{ __('Código') }}</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">{{ __('Categoría') }}</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">{{ __('Stock') }}</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">{{ __('Precio venta') }}</th>
+                                <th scope="col" class="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">{{ __('Acciones') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200 bg-white">
+                            @forelse ($products as $product)
+                                <tr>
+                                    <td class="px-6 py-4 text-sm text-gray-500">
+                                        @if ($product->image)
+                                            <img src="{{ asset('storage/'.$product->image) }}" alt="{{ $product->name }}" class="h-12 w-12 rounded object-cover">
+                                        @else
+                                            <span class="text-xs text-gray-400">{{ __('Sin imagen') }}</span>
+                                        @endif
+                                    </td>
+                                    <td class="px-6 py-4 text-sm font-medium text-gray-900">{{ $product->name }}</td>
+                                    <td class="px-6 py-4 text-sm text-gray-500">{{ $product->code }}</td>
+                                    <td class="px-6 py-4 text-sm text-gray-500">{{ $product->category->name ?? __('Sin categoría') }}</td>
+                                    <td class="px-6 py-4 text-sm text-gray-500">{{ $product->stock }}</td>
+                                    <td class="px-6 py-4 text-sm text-gray-500">${{ number_format($product->sale_price, 2) }}</td>
+                                    <td class="px-6 py-4 text-right text-sm font-medium">
+                                        <div class="flex justify-end gap-2">
+                                            <a href="{{ route('products.edit', $product) }}" class="inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-xs font-semibold text-indigo-600 shadow-sm ring-1 ring-inset ring-indigo-200 transition hover:bg-indigo-50">
+                                                {{ __('Editar') }}
+                                            </a>
+                                            <form action="{{ route('products.destroy', $product) }}" method="POST" onsubmit="return confirm('{{ __('¿Eliminar el producto?') }}');">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-xs font-semibold text-red-600 shadow-sm ring-1 ring-inset ring-red-200 transition hover:bg-red-50">
+                                                    {{ __('Eliminar') }}
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="7" class="px-6 py-12 text-center text-sm text-gray-500">{{ __('Aún no hay productos registrados.') }}</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
 
-    <table class="table table-bordered">
-        <thead>
-            <tr>
-                <th>Imagen</th>
-                <th>Nombre</th>
-                <th>Código</th>
-                <th>Categoría</th>
-                <th>Stock</th>
-                <th>Precio Venta</th>
-                <th>Acciones</th>
-            </tr>
-        </thead>
-        <tbody>
-        @foreach($products as $product)
-            <tr>
-                <td>
-                    @if($product->image)
-                        <img src="{{ asset('storage/'.$product->image) }}" width="60">
-                    @endif
-                </td>
-                <td>{{ $product->name }}</td>
-                <td>{{ $product->code }}</td>
-                <td>{{ $product->category->name ?? '-' }}</td>
-                <td>{{ $product->stock }}</td>
-                <td>${{ $product->sale_price }}</td>
-                <td>
-                    <a href="{{ route('products.edit',$product) }}" class="btn btn-sm btn-warning">Editar</a>
-                    <form action="{{ route('products.destroy',$product) }}" method="POST" style="display:inline;">
-                        @csrf @method('DELETE')
-                        <button class="btn btn-sm btn-danger" onclick="return confirm('¿Eliminar?')">Borrar</button>
-                    </form>
-                </td>
-            </tr>
-        @endforeach
-        </tbody>
-    </table>
-
-    {{ $products->links() }}
-</div>
-@endsection
+            <div class="mt-6">
+                {{ $products->links() }}
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/users/dashboard.blade.php
+++ b/resources/views/users/dashboard.blade.php
@@ -1,8 +1,18 @@
-@extends('layouts.app')
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800">
+            {{ __('Panel de usuario') }}
+        </h2>
+    </x-slot>
 
-@section('content')
-<div class="p-6">
-  <h1 class="text-2xl font-bold">Panel de Usuario</h1>
-  <p class="mt-2">Hola, {{ auth()->user()->name }}</p>
-</div>
-@endsection
+    <div class="py-12">
+        <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+            <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <h1 class="text-2xl font-bold">{{ __('Hola, :name', ['name' => auth()->user()->name]) }}</h1>
+                    <p class="mt-2 text-sm text-gray-600">{{ __('Aquí encontrarás un resumen de tus actividades y notificaciones importantes.') }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ProductController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 
@@ -22,7 +23,6 @@ Route::get('/', function () {
 
 // Grupo de rutas protegidas (auth + email verificado)
 Route::middleware(['auth', 'verified'])->group(function () {
-
     // Dashboard general
     Route::get('/dashboard', function () {
         return view('dashboard');
@@ -33,19 +33,20 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
-    // Panel Admin (solo usuarios con rol admin)
-    Route::get('/admin', function () {
-        return view('admin.dashboard');
-    })->middleware('role:admin')->name('admin.dashboard');
-
     // Panel Usuario (cualquier usuario logueado)
     Route::get('/user', function () {
-        return view('user.dashboard');
+        return view('users.dashboard');
     })->name('user.dashboard');
+
+    // Panel Admin (solo usuarios con rol admin)
+    Route::middleware('role:admin')->group(function () {
+        Route::get('/admin', function () {
+            return view('admin.dashboard');
+        })->name('admin.dashboard');
+
+        Route::resource('products', ProductController::class);
+    });
 });
-
-Route::resource('products', ProductController::class)->middleware(['auth','role:admin']);
-
 
 // Rutas de autenticación (login, register, forgot password, etc.)
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- restore the full Laravel HTTP kernel so the framework middleware stack loads correctly while keeping the custom role alias
- harden the product CRUD flow with proper validation, image handling, Tailwind-based layouts, and secure routing for the admin panel
- complete the inventory domain by updating models and migrations for categories, products, suppliers, customers, purchases, and sales with the needed relationships and schema

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing because dependencies could not be installed in this environment)*
- `composer install` *(fails: GitHub returned HTTP 403 when downloading packages, so dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d55744ef4883319fab9f622a837325